### PR TITLE
Added a feature that opens the main.c/pp file after the project is created

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -21,10 +21,14 @@ export namespace project {
                 case 'c':
                     fs.writeFileSync(path.join(location, 'src', 'main.c'), content.main_c);
                     fs.writeFileSync(path.join(location, 'Makefile'), content.makefile_c);
+                    vscode.workspace.openTextDocument(path.join(location, 'src', 'main.c'))
+                        .then(doc => vscode.window.showTextDocument(doc, { preview: false }));
                     break;
                 case 'cpp':
                     fs.writeFileSync(path.join(location, 'src', 'main.cpp'), content.main_cpp);
                     fs.writeFileSync(path.join(location, 'Makefile'), content.makefile_cpp);
+                    vscode.workspace.openTextDocument(path.join(location, 'src', 'main.cpp'))
+                        .then(doc => vscode.window.showTextDocument(doc, { preview: false }));
                     break;
                 default:
                     console.log('Invalid file type');


### PR DESCRIPTION
I saw that this was listed as a known issue on the README and I also find it pretty useful to automatically open the file after creating the project.

I don't know if this is the best way to do it, but it works as expected and I haven't had any issues.