### PR TITLE
fix to issue #101

### DIFF
--- a/templates/cpp/Makefile
+++ b/templates/cpp/Makefile
@@ -1,5 +1,6 @@
-CC		:= g++
-CFLAGS	:= -std=c++17 -Wall -Wextra -g
+CXX		:= g++
+CXXFLAGS	:= -std=c++17 -Wall -Wextra -g
+LDFLAGS		:=
 
 BIN		:= bin
 SRC		:= src
@@ -38,4 +39,4 @@ run: all
 	./$(BIN)/$(EXECUTABLE)
 
 $(BIN)/$(EXECUTABLE): $(OBJECTS)
-	$(CC) $(CFLAGS) $(CINCLUDES) $(CLIBS) $^ -o $@ $(LIBRARIES)
+	$(CXX) $(LDFLAGS) $(CINCLUDES) $(CLIBS) $^ -o $@ $(LIBRARIES)


### PR DESCRIPTION
In C++ project makefile uses variable `CXXFLAGS` to include additional parameters to the compiler

makefile is quite smart in case of compiling C++ files, it knows that to execute target from line 40, it needs files with `.o` extension, and it has files with `.cpp` extension, so it uses default target to compile `.cpp` files into `.o`
 
Lines 40-41 are used not for compiling, but for linking, therefore it does not require `CXXFLAGS`, which are used only in compilation process