### PR TITLE
Create ./bin/ directory if it does not exist

### DIFF
--- a/templates/c/Makefile
+++ b/templates/c/Makefile
@@ -8,6 +8,7 @@ LIB		:= lib
 
 LIBRARIES	:=
 
+MD 		:= mkdir
 ifeq ($(OS),Windows_NT)
 EXECUTABLE	:= main.exe
 SOURCEDIRS	:= $(SRC)
@@ -26,7 +27,10 @@ CLIBS		:= $(patsubst %,-L%, $(LIBDIRS:%/=%))
 SOURCES		:= $(wildcard $(patsubst %,%/*.c, $(SOURCEDIRS)))
 OBJECTS		:= $(SOURCES:.c=.o)
 
-all: $(BIN)/$(EXECUTABLE)
+all: $(BIN) $(BIN)/$(EXECUTABLE)
+
+$(BIN):
+	$(MD) -p $(BIN)
 
 .PHONY: clean
 clean:

--- a/templates/cpp/Makefile
+++ b/templates/cpp/Makefile
@@ -8,12 +8,15 @@ LIB		:= lib
 
 LIBRARIES	:=
 
+
+MD 		:= mkdir
 ifeq ($(OS),Windows_NT)
 EXECUTABLE	:= main.exe
 SOURCEDIRS	:= $(SRC)
 INCLUDEDIRS	:= $(INCLUDE)
 LIBDIRS		:= $(LIB)
 else
+
 EXECUTABLE	:= main
 SOURCEDIRS	:= $(shell find $(SRC) -type d)
 INCLUDEDIRS	:= $(shell find $(INCLUDE) -type d)
@@ -26,7 +29,10 @@ CLIBS		:= $(patsubst %,-L%, $(LIBDIRS:%/=%))
 SOURCES		:= $(wildcard $(patsubst %,%/*.cpp, $(SOURCEDIRS)))
 OBJECTS		:= $(SOURCES:.cpp=.o)
 
-all: $(BIN)/$(EXECUTABLE)
+all: $(BIN) $(BIN)/$(EXECUTABLE)
+
+$(BIN):
+	$(MD) -p $(BIN)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
If bin/ directory does not exist, it should be created

Sometimes users will delete this dir, and it will cause the linking process to fail. It can be prevented by simple makefile action