### PR TITLE
modifying header file will trigger a rebuild

### DIFF
--- a/templates/cpp/Makefile
+++ b/templates/cpp/Makefile
@@ -78,14 +78,17 @@ $(MAIN): $(OBJECTS)
 # the rule(a .c file) and $@: the name of the target of the rule (a .o file) 
 # (see the gnu make manual section about automatic variables)
 .cpp.o:
-	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $<  -o $@
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c -MMD $<  -o $@
 
 .PHONY: clean
 clean:
 	$(RM) $(OUTPUTMAIN)
 	$(RM) $(call FIXPATH,$(OBJECTS))
+	$(RM) $(call FIXPATH,$(SRC)/*.d)
 	@echo Cleanup complete!
 
 run: all
 	./$(OUTPUTMAIN)
 	@echo Executing 'run: all' complete!
+
+-include $(call FIXPATH,$(SRC)/*.d)

--- a/templates/cpp/Makefile
+++ b/templates/cpp/Makefile
@@ -56,6 +56,9 @@ SOURCES		:= $(wildcard $(patsubst %,%/*.cpp, $(SOURCEDIRS)))
 # define the C object files 
 OBJECTS		:= $(SOURCES:.cpp=.o)
 
+# define the dependency output files
+DEPS		:= $(OBJECTS:.o=.d)
+
 #
 # The following part of the makefile is generic; it can be used to 
 # build any executable just by changing the definitions above and by
@@ -73,6 +76,9 @@ $(OUTPUT):
 $(MAIN): $(OBJECTS) 
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -o $(OUTPUTMAIN) $(OBJECTS) $(LFLAGS) $(LIBS)
 
+# include all .d files
+-include $(DEPS)
+
 # this is a suffix replacement rule for building .o's from .c's
 # it uses automatic variables $<: the name of the prerequisite of
 # the rule(a .c file) and $@: the name of the target of the rule (a .o file) 
@@ -84,11 +90,9 @@ $(MAIN): $(OBJECTS)
 clean:
 	$(RM) $(OUTPUTMAIN)
 	$(RM) $(call FIXPATH,$(OBJECTS))
-	$(RM) $(call FIXPATH,$(SRC)/*.d)
+	$(RM) $(call FIXPATH,$(DEPS))
 	@echo Cleanup complete!
 
 run: all
 	./$(OUTPUTMAIN)
 	@echo Executing 'run: all' complete!
-
--include $(call FIXPATH,$(SRC)/*.d)

--- a/templates/cpp/Makefile
+++ b/templates/cpp/Makefile
@@ -79,9 +79,10 @@ $(MAIN): $(OBJECTS)
 # include all .d files
 -include $(DEPS)
 
-# this is a suffix replacement rule for building .o's from .c's
+# this is a suffix replacement rule for building .o's and .d's from .c's
 # it uses automatic variables $<: the name of the prerequisite of
 # the rule(a .c file) and $@: the name of the target of the rule (a .o file) 
+# -MMD generates dependency output files same name as the .o file
 # (see the gnu make manual section about automatic variables)
 .cpp.o:
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c -MMD $<  -o $@


### PR DESCRIPTION
After successfully building a program or running make, if a user were to change a header file only and run make again. This won't rebuild the program. The updated Makefile template ensures that the program will update even when only header files are updated.