### PR TITLE
Project creation with project name and parent directory selection

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -21,15 +21,22 @@ export class Project {
             const mainPath = path.join(this.context.extensionPath, 'templates', type, `main.${type}`);
             const makefilePath = path.join(this.context.extensionPath, 'templates', type, 'Makefile');
 
+            // Ensure .vscode and src directories exist before writing files into them
+            await fs.ensureDir(path.join(location, '.vscode'));
             fs.writeFileSync(path.join(location, '.vscode', 'tasks.json'), fs.readFileSync(tasksPath, 'utf-8'));
             fs.writeFileSync(path.join(location, '.vscode', 'launch.json'), fs.readFileSync(launchPath, 'utf-8'));
+
+            await fs.ensureDir(path.join(location, 'src'));
             fs.writeFileSync(path.join(location, 'src', `main.${type}`), fs.readFileSync(mainPath, 'utf-8'));
+
             fs.writeFileSync(path.join(location, 'Makefile'), fs.readFileSync(makefilePath, 'utf-8'));
 
-            vscode.workspace.openTextDocument(path.join(location, 'src', 'main.cpp'))
+            // Open the main file after creation
+            vscode.workspace.openTextDocument(path.join(location, 'src', `main.${type}`))
                 .then(doc => vscode.window.showTextDocument(doc, { preview: false }));
         } catch (err) {
             console.error(err);
+            vscode.window.showErrorMessage(`Error creating project files: ${err}`);
         }
     }
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -42,13 +42,16 @@ export class Project {
 
 
     async createFolders(location: string) {
-        this.directories.forEach((dir: string) => {
+        // Use Promise.all for potentially faster parallel directory creation
+        await Promise.all(this.directories.map(async (dir: string) => {
             try {
-                fs.ensureDirSync(path.join(location, dir));
+                await fs.ensureDir(path.join(location, dir));
             } catch (err) {
                 console.error(err);
+                vscode.window.showErrorMessage(`Error creating directory ${dir}: ${err}`);
+                throw err; // Re-throw to stop the process if a folder fails
             }
-        });
+        }));
     }
 
     async createProject(type: string) {

--- a/src/vscode-ui.ts
+++ b/src/vscode-ui.ts
@@ -1,7 +1,14 @@
 import { OpenDialogOptions, Uri, window } from 'vscode';
 
 export class VSCodeUI {
-    static async openDialogForFolder(): Promise<Uri> {
+    static async promptForProjectName(): Promise<string | undefined> {
+        const projectName = await window.showInputBox({
+            prompt: 'Enter the name for your new project',
+            placeHolder: 'e.g., my_c_project'
+        });
+        return projectName;
+    }
+
         const options: OpenDialogOptions = {
             canSelectFiles: false,
             canSelectFolders: true,

--- a/src/vscode-ui.ts
+++ b/src/vscode-ui.ts
@@ -1,4 +1,5 @@
-import { OpenDialogOptions, Uri, window } from 'vscode';
+import { OpenDialogOptions, Uri, window, workspace } from 'vscode';
+import { homedir } from 'os';
 
 export class VSCodeUI {
     static async promptForProjectName(): Promise<string | undefined> {
@@ -9,16 +10,25 @@ export class VSCodeUI {
         return projectName;
     }
 
+    // NEW: Prompt for parent directory using Open Dialog
+    static async promptForParentDirectory(projectName: string): Promise<Uri | undefined> {
+        const defaultUri = workspace.workspaceFolders && workspace.workspaceFolders.length > 0
+            ? workspace.workspaceFolders[0].uri
+            : Uri.file(homedir());
+
         const options: OpenDialogOptions = {
             canSelectFiles: false,
             canSelectFolders: true,
-            canSelectMany: false
+            canSelectMany: false,
+            defaultUri: defaultUri,
+            title: `Select Parent Directory for Project '${projectName}'`
         };
-        const result: Uri[] | undefined = await window.showOpenDialog(Object.assign(options));
+
+        const result: Uri[] | undefined = await window.showOpenDialog(options);
         if (result && result.length) {
-            return Promise.resolve(result[0]);
+            return result[0]; // Return the selected parent directory URI
         } else {
-            return Promise.reject();
+            return undefined; // User cancelled
         }
     }
 }


### PR DESCRIPTION
This PR introduces a similar workflow:

- Prompt for a Project Name and Parent Directory up front
- Automatically create the corresponding folder structure under the selected parent
- Streamline the initial setup so new projects are ready to go without extra manual steps

I believe this small enhancement will make onboarding easier for learners(students). Would you be okay with adding this feature? I’m happy to refine the implementation or adjust the UX based on your feedback.

Looking forward to your thoughts.


https://github.com/user-attachments/assets/caa9cd26-3478-460a-8462-b5c38aaf7dc7

